### PR TITLE
Issue-19 remove deprecated references to influxdb community module

### DIFF
--- a/tasks/config_db.yml
+++ b/tasks/config_db.yml
@@ -19,7 +19,7 @@
     port: "{{ influxdb_http['bind_port'] }}"
 
 - name: config_db | Creating InfluxDB(s)
-  community.general.database.influxdb.influxdb_database:
+  community.general.influxdb_database:
     hostname: "{{ item['host'] }}"
     database_name: "{{ item['name'] }}"
     state: "{{ item['state'] }}"
@@ -29,7 +29,7 @@
   loop: "{{ influxdb_databases }}"
 
 - name: config_db | Creating InfluxDB Retention Policies
-  community.general.database.influxdb.influxdb_retention_policy:
+  community.general.influxdb_retention_policy:
     hostname: "{{ item['host'] }}"
     database_name: "{{ item['name'] }}"
     policy_name: "{{ item['retention_policy']['name'] }}"


### PR DESCRIPTION
Solve deprecation warning for ansible community modules

## Description
using the long path of for the influxdb components:
 * `community.general.database.influxdb_database` 
 * `community.general.database.influxdb_retention_policy`

Is deprecated. Renaming them to the:
 * `community.general.influxdb_database`
 * `community.general.influxdb_retention_policy` 


## Related Issue
https://github.com/mrlesmithjr/ansible-influxdb/issues/19

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
